### PR TITLE
add locales-all for R2020a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ libxss1 \
 libxt6 \
 libxtst6 \
 libxxf86vm1 \
+locales-all \
 procps \
 xkb-data \
 xvfb \


### PR DESCRIPTION
Without installing locales-all R2020a fails in docker fails with `Catastrophic error: could not set locale "en_US.UTF-8" to allow processing of multibyte characters`