### PR TITLE
fix hadolint DL3009 warning for cleaning up the apt-get lists after installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
         wget \
         unzip \
         ca-certificates && \
-    apt-get clean && apt-get autoremove
+    apt-get clean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
 
 # Run mpm to install MATLAB in the target location and delete the mpm installation afterwards
 RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \ 


### PR DESCRIPTION
Standard procedure for creating Docker containers where I work includes running the Dockerfiles through [hadolint](https://github.com/hadolint/hadolint). With the current reference Dockerfile, hadolint gives the reference architecture an error for violating [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009), which is a recommendation aimed at reducing the container size. 

As we know, the Matlab container can be quite large, so any size reduction is generally favorable.