### PR TITLE
Allow addition of Extra Products using Build Arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@
 # To specify which MATLAB release to install in the container, edit the value of the MATLAB_RELEASE argument.
 # Use lower case to specify the release, for example: ARG MATLAB_RELEASE=r2021b
 ARG MATLAB_RELEASE=r2023a
+ARG EXTRA_PRODUCTS=""
 
 # When you start the build stage, this Dockerfile by default uses the Ubuntu-based matlab-deps image.
 # To check the available matlab-deps images, see: https://hub.docker.com/r/mathworks/matlab-deps
 FROM mathworks/matlab-deps:${MATLAB_RELEASE}
+ARG EXTRA_PRODUCTS
 
 # Declare the global argument to use at the current build stage
 ARG MATLAB_RELEASE
@@ -29,7 +31,7 @@ RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm \
     && ./mpm install \
     --release=${MATLAB_RELEASE} \
     --destination=/opt/matlab \
-    --products MATLAB \
+    --products MATLAB ${EXTRA_PRODUCTS} \
     || (echo "MPM Installation Failure. See below for more information:" && cat /tmp/mathworks_root.log && false) \
     && rm -f mpm /tmp/mathworks_root.log \
     && ln -s /opt/matlab/bin/matlab /usr/local/bin/matlab


### PR DESCRIPTION
Pass in EXTRA_PROUCTS to allow installation of e.g. toolboxes, rather than needing to modify the Dockerfile for simple usecases.

Afraid this isn't properly tested yet due to #57. However the image builds and this seems a simple enough fix to me. 