### PR TITLE
Update Dockerfile - addresses license folder exists

### DIFF
--- a/alternates/matlab-installer/Dockerfile
+++ b/alternates/matlab-installer/Dockerfile
@@ -84,7 +84,7 @@ RUN cd /matlab-install \
         exit 1; fi
 
 # If you did not specify a license server at build, comment these lines.
-RUN mkdir /usr/local/MATLAB/licenses \
+RUN mkdir -p /usr/local/MATLAB/licenses \
     && cp /tmp/network.lic /usr/local/MATLAB/licenses/
 
 # Build final container image.


### PR DESCRIPTION
During local testing had to add a -p when providing no license file and just the fileInstallationKey.  Received the following error

`mkdir: cannot create directory '/usr/local/MATLAB/licenses': File exists`

Once this was done created correctly and verified with the `-batch "ver"` command
