### PR TITLE
Remove --release option from invocation using --source

### DIFF
--- a/MPM.md
+++ b/MPM.md
@@ -190,11 +190,11 @@ Install products from this image by specifying the path to the image in the `sou
 
 * Linux or macOS:
 
-      ./mpm install --release=R2024a --source=/path/to/mounted/image --products MATLAB Simulink
+      ./mpm install --source=/path/to/mounted/image --products MATLAB Simulink
 
 * Windows *(run as administrator)*:
 
-      .\mpm.exe install --release=R2024a --source="\path\to\mounted\image" --products MATLAB Simulink
+      .\mpm.exe install --source="\path\to\mounted\image" --products MATLAB Simulink
 
 
 ### Install Documentation and Examples


### PR DESCRIPTION
This pull request removes the `--release` option from lines demonstrating `mpm` with the `--source` option in the documentation. You cannot specify the `--release` option with the `--source` option. 

Per `mpm`:

```
$ ./mpm install --release=R2024a --source=/Volumes/R2024a_Update_4_macOSIntelProcessor --products MATLAB Simulink
Error: Invalid option combination. Specify either --release or --source.
```