### PR TITLE
modify the noticable alert marker Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 This repository shows you how to build and customize a Docker&reg; container for MATLAB&reg; and its toolboxes, using the [MATLAB Package Manager](https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md) (`mpm`). You can use this container image as a scalable and reproducible method to deploy and test your MATLAB code.
 
-Use the [Dockerfile](Dockerfile) in this top-level repository if you want a lightweight and simple way to create a MATLAB container image. You can also download prebuilt images based on the Dockerfile from [here](https://github.com/mathworks-ref-arch/matlab-dockerfile/pkgs/container/matlab-dockerfile%2Fmatlab). 
+Use the [Dockerfile](Dockerfile) in this top-level repository if you want a lightweight and simple way to create a MATLAB container image. You can also download prebuilt images based on the Dockerfile from [here](https://github.com/mathworks-ref-arch/matlab-dockerfile/pkgs/container/matlab-dockerfile%2Fmatlab).
 
-For alternative resources, see the [**alternates folder**](alternates) that contains the following Dockerfiles: 
+For alternative resources, see the [**alternates folder**](alternates) that contains the following Dockerfiles:
 
 * The Dockerfile in [matlab-installer](alternates/matlab-installer) uses the MATLAB installer rather than `mpm` to install MATLAB in the container. This allows you to install toolboxes that are not currently supported by mpm. Use this Dockerfile if you prefer using the MATLAB installer workflow, instead of `mpm`.
 * The Dockerfile in [building-on-matlab-docker-image](alternates/building-on-matlab-docker-image) shows you how to build on top of the [MATLAB Container Image on Docker Hub](https://hub.docker.com/r/mathworks/matlab). Use this Dockerfile if you want to install extra toolboxes on top of the `mathworks/matlab` container image. This Dockerfile contains the features of the MATLAB image on Docker Hub, allowing you to access the dockerised MATLAB through a browser, batch mode, or an interactive command prompt.
 * The Dockerfile in [non-interactive](alternates/non-interactive) allows you run MATLAB in non-interactive environments. This Dockerfile requires that you have a MATLAB batch licensing token to license MATLAB in the container. Use this Dockerfile in continuous integration and continuous delivery (CI/CD) pipelines or other automated environments where interactive licensing is not possible.
 * The Dockerfile in [matlab-container-offline-install](alternates/matlab-container-offline-install/) shows you how to build and customize a Docker container for MATLAB and its toolboxes in an offline environment. Use this Dockerfile if you must build your container image in an offline environment.
 
-For more Docker related resources, see [More MATLAB Docker Resources](#more-matlab-docker-resources). 
+For more Docker related resources, see [More MATLAB Docker Resources](#more-matlab-docker-resources).
 
 ### Requirements
+
 * [A running network license manager for MATLAB](https://www.mathworks.com/help/install/administer-network-licenses.html) — For more information, see [Using the Network License Manager](#use-the-network-license-manager).
 * Docker.
 
@@ -24,6 +25,7 @@ For more Docker related resources, see [More MATLAB Docker Resources](#more-matl
 Access the Dockerfile either by directly downloading this repository from GitHub&reg;,
 or by cloning this repository and
 then navigating to the appropriate folder.
+
 ```bash
 git clone https://github.com/mathworks-ref-arch/matlab-dockerfile.git
 cd matlab-dockerfile
@@ -32,25 +34,27 @@ cd matlab-dockerfile
 ### Build and Run Docker Image
 
 Build container with a name and tag of your choice.
+
 ```bash
 docker build -t matlab:R2024b .
 ```
 
 Run the container. Test the container by running an example MATLAB command, such as `ver`.
+
 ```bash
 docker run --init --rm -e MLM_LICENSE_FILE=27000@MyServerName matlab:R2024b -batch ver
 ```
+
 The [Dockerfile](https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/Dockerfile) defaults to building a container for MATLAB R2024b.
 
 The example command `ver` displays the version number of MATLAB and other installed products. For more information, see [`ver`](https://www.mathworks.com/help/matlab/ref/ver.html). For more information on running the container, see the [Run the Container](#run-the-container) section.
 
-> **Note**
->
+> [!NOTE]
 > Use the `--init` flag in the `docker run` command to ensure that the container stops gracefully when a `docker stop` or `docker kill` command is issued.
 > For more information, see these links:
+>
 > * [Reference page for `docker run`](https://docs.docker.com/reference/cli/docker/container/run/#init)
 > * [Blog post on the usage of init](https://www.baeldung.com/ops/docker-init-parameter)
-
 
 ## Customize the Image
 
@@ -59,6 +63,7 @@ By default, the [Dockerfile](https://github.com/mathworks-ref-arch/matlab-docker
 Use the options below to customize your build.
 
 ### Customize MATLAB Release, MATLAB Product List, MATLAB Install Location, and License Server
+
 The [Dockerfile](https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/Dockerfile) supports these Docker build-time variables:
 
 | Argument Name | Default value | Description |
@@ -72,19 +77,25 @@ Use these arguments with the the `docker build` command to customize your image.
 Alternatively, you can change the default values for these arguments directly in the [Dockerfile](https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/Dockerfile).
 
 #### Build an Image for a Different MATLAB Release
+
 For example, to build an image for MATLAB R2019b, use this command.
+
 ```bash
 docker build --build-arg MATLAB_RELEASE=R2019b -t matlab:R2019b .
 ```
 
 #### Build an Image with a Specific Set of Products
+
 For example, to build an image with MATLAB and Simulink&reg;, use this command.
+
 ```bash
 docker build --build-arg MATLAB_PRODUCT_LIST='MATLAB Simulink' -t matlab:R2024b .
 ```
 
 #### Build an Image with MATLAB Installed to a Specific Location
+
 For example, to build an image with MATLAB installed at /opt/matlab, use this command.
+
 ```bash
 docker build --build-arg MATLAB_INSTALL_LOCATION='/opt/matlab' -t matlab:R2024b .
 ```
@@ -92,6 +103,7 @@ docker build --build-arg MATLAB_INSTALL_LOCATION='/opt/matlab' -t matlab:R2024b 
 #### Build an Image Configured to Use a License Server
 
 Including the license server information with the `docker build` command means you do not have to pass it when running the container.
+
 ```bash
 # Build container with the license server.
 docker build --build-arg LICENSE_SERVER=27000@MyServerName -t matlab:R2024b .
@@ -101,6 +113,7 @@ docker run --init --rm matlab:R2024b -batch ver
 ```
 
 ## Use the Network License Manager
+
 This container requires a network license manager to license and run MATLAB. You need either the port and hostname of the network license manager or a `network.lic` file.
 
 **Step 1**: Contact your system administrator, who can provide one of the following:
@@ -108,6 +121,7 @@ This container requires a network license manager to license and run MATLAB. You
 * The address to your server, and the port it is running on, for example, `27000@MyServerName.example.com`
 
 * A `network.lic` file containing these lines.
+
     ```bash
     # Sample network.lic
     SERVER MyServerName.example.com <optional-mac-address> 27000
@@ -120,18 +134,20 @@ This container requires a network license manager to license and run MATLAB. You
     # Snippet from sample license.dat
     SERVER MyServerName.example.com <mac-address> 27000
     ```
+
 ---
 **Step 2**: Use `port@hostname` or the `network.lic` file with either the `docker build` **or** the `docker run` command.
 
 With the `docker build` command, either:
 
-- Specify the `LICENSE_SERVER` build-arg.
+* Specify the `LICENSE_SERVER` build-arg.
 
     ```bash
     # Example
     docker build -t matlab:R2024b --build-arg LICENSE_SERVER=27000@MyServerName .
     ```
-- Use the `network.lic` file.
+
+* Use the `network.lic` file.
     1. Place the `network.lic` file in the same folder as the Dockerfile.
     1. Uncomment the line `COPY network.lic /opt/matlab/licenses/` in the Dockerfile.
     1. Run the `docker build` command **without** the `LICENSE_SERVER` build-arg:
@@ -140,14 +156,15 @@ With the `docker build` command, either:
     # Example
     docker build -t matlab:R2024b .
     ```
-    
-With the `docker run` command, use the `MLM_LICENSE_FILE` environment variable. 
+
+With the `docker run` command, use the `MLM_LICENSE_FILE` environment variable.
 
 ```bash
 docker run --init --rm -e MLM_LICENSE_FILE=27000@MyServerName matlab:R2024b -batch ver
 ```
 
 ## Run the Container
+
 If you did not provide the license server information when building the image, then provide it when running the container. Set the environment variable `MLM_LICENSE_FILE` using the `-e` flag, with the  network license manager's location in the format `port@hostname`.
 
 ```bash
@@ -158,44 +175,54 @@ docker run --init --rm -e MLM_LICENSE_FILE=27000@MyServerName matlab:R2024b -bat
 You can run the container **without** specifying `MLM_LICENSE_FILE` if you provided the license server information when building the image, as shown in the examples below.
 
 ### Run MATLAB in an Interactive Command Prompt
+
 To start the container and run MATLAB in an interactive command prompt, use this command.
+
 ```bash
 docker run --init -it --rm matlab:R2024b
 ```
+
 ### Run MATLAB in Batch Mode
+
 To start the container, run a MATLAB command, and then exit, use this command.
+
 ```bash
 # Container runs the command RAND in MATLAB and exits.
 docker run --init --rm matlab:R2024b -batch rand
 ```
 
 ### Run MATLAB with Startup Options
+
 To override the default behavior of the container and run MATLAB with any set of arguments, such as `-logfile`, use this command.
+
 ```bash
 docker run --init -it --rm matlab:R2024b -logfile "logfilename.log"
 ```
+
 To learn more, see the documentation: [Commonly Used Startup Options](https://www.mathworks.com/help/matlab/matlab_env/commonly-used-startup-options.html).
 
-
 ## More MATLAB Docker Resources
-* Explore prebuilt MATLAB Docker Containers on Docker Hub: https://hub.docker.com/r/mathworks.
-    * [MATLAB Containers on Docker Hub](https://hub.docker.com/r/mathworks/matlab) hosts container images for multiple releases of MATLAB.
-    * [MATLAB Deep Learning Containers on Docker Hub](https://hub.docker.com/r/mathworks/matlab-deep-learning) hosts container images with toolboxes suitable for Deep Learning.
-* Enable additional capabilities using the [MATLAB Dependencies repository](https://github.com/mathworks-ref-arch/container-images/tree/main/matlab-deps). 
+
+* Explore prebuilt MATLAB Docker Containers on Docker Hub: <https://hub.docker.com/r/mathworks>.
+  * [MATLAB Containers on Docker Hub](https://hub.docker.com/r/mathworks/matlab) hosts container images for multiple releases of MATLAB.
+  * [MATLAB Deep Learning Containers on Docker Hub](https://hub.docker.com/r/mathworks/matlab-deep-learning) hosts container images with toolboxes suitable for Deep Learning.
+* Enable additional capabilities using the [MATLAB Dependencies repository](https://github.com/mathworks-ref-arch/container-images/tree/main/matlab-deps).
 For some workflows and toolboxes, you must specify dependencies. You must do this if you want to do these tasks:
-    * Install extended localization support for MATLAB
-    * Play media files from MATLAB
-    * Generate code from Simulink
-    * Use mex functions with gcc, g++, or gfortran
-    * Use the MATLAB Engine API for C and Fortran&reg;
-    * Use the Polyspace&reg; 32-bit tcc compiler
-    
+  * Install extended localization support for MATLAB
+  * Play media files from MATLAB
+  * Generate code from Simulink
+  * Use mex functions with gcc, g++, or gfortran
+  * Use the MATLAB Engine API for C and Fortran&reg;
+  * Use the Polyspace&reg; 32-bit tcc compiler
+
     The [MATLAB Dependencies repository](https://github.com/mathworks-ref-arch/container-images/tree/main/matlab-deps) lists Dockerfiles for various releases and platforms. To view the Dockerfile for R2024b, click [here](https://github.com/mathworks-ref-arch/container-images/blob/main/matlab-deps/r2024b/ubuntu22.04/Dockerfile).
 
     These Dockerfiles contain commented lines with the libraries that support additional capabilities. Copy and uncomment these lines into your Dockerfile.
 
 ## Help Make MATLAB Even Better
+
 You can help improve MATLAB by providing user experience information on how you use MathWorks products. Your participation ensures that you are represented and helps us design better products. To opt out of this service, delete this line in the Dockerfile.
+
 ```Dockerfile
 ENV MW_DDUX_FORCE_ENABLE=true MW_CONTEXT_TAGS=MATLAB:DOCKERFILE:V1
 ```
@@ -203,6 +230,7 @@ ENV MW_DDUX_FORCE_ENABLE=true MW_CONTEXT_TAGS=MATLAB:DOCKERFILE:V1
 To learn more, see the documentation: [Help Make MATLAB Even Better - Frequently Asked Questions](https://www.mathworks.com/support/faq/user_experience_information_faq.html).
 
 ## Feedback
+
 We encourage you to try this repository with your environment and provide feedback. If you encounter a technical issue or have an enhancement request, create an issue [here](https://github.com/mathworks-ref-arch/matlab-dockerfile/issues).
 
 ----

--- a/alternates/matlab-container-offline-install/README.md
+++ b/alternates/matlab-container-offline-install/README.md
@@ -5,8 +5,9 @@ The Dockerfiles in this subfolder show you how to build and customize a Docker&r
 The solution uses two Docker images. The first image (archive image) contains the installation files that are required by *mpm* to install from source. The second image (product image) uses the archive image to get the installation files for MATLAB, toolboxes and support packages that you want to install.
 
 ### Requirements
+
 * [A Running Network License Manager for MATLAB](https://www.mathworks.com/help/install/administer-network-licenses.html)
-    * For more information, see [Use the Network License Manager](../../README.md#use-the-network-license-manager)
+  * For more information, see [Use the Network License Manager](../../README.md#use-the-network-license-manager)
 * Docker >= 20.10
 
 ## Build Instructions
@@ -19,12 +20,16 @@ Access the Dockerfiles either by directly downloading this repository from GitHu
 git clone https://github.com/mathworks-ref-arch/matlab-dockerfile.git
 cd matlab-dockerfile/alternates/matlab-container-offline-install
 ```
+
 ### Build the Archive Docker Image
-> :warning: Note: You must run this step in an online environment.
+>
+> [!WARNING]
+> You must run this step in an online environment.
 
 You can then store the generated Docker build and copy it to the offline or air-gapped environment for the next step.
 
 Build the archive image with a name and tag.
+
 ```bash
 docker build -t mpm-archive:R2024b -f archive.Dockerfile .
 ```
@@ -34,12 +39,15 @@ By default, the [archive.Dockerfile](archive.Dockerfile) downloads the latest av
 To customize the build of the archive image, refer to [Customize the Archive Docker Image](#customize-the-archive-docker-image).
 
 ### Build the Product Docker Image
+
 To run this step in an offline or air-gapped environment, you need:
+
 * The [mathworks/matlab-deps](https://hub.docker.com/r/mathworks/matlab-deps) image in your local Docker registry.
 * The mpm-archive image in your local Docker registry.
 * A Docker environment with [BuildKit enabled](https://docs.docker.com/build/buildkit/#getting-started).
 
 Build a container with a name and tag.
+
 ```bash
 DOCKER_BUILDKIT=1 docker build -t matlab-from-source:R2024b .
 ```
@@ -47,9 +55,11 @@ DOCKER_BUILDKIT=1 docker build -t matlab-from-source:R2024b .
 To customize the build of the product image, refer to [Customize the Product Docker Image](#customize-the-product-docker-image).
 
 ## Customization Instructions
+
 Follow these instructions if you want to customize the build of the archive and product Docker images.
 
 ### Customize the Archive Docker Image
+
 The [archive.Dockerfile](archive.Dockerfile) supports the following Docker build-time variables:
 
 | Argument Name | Default value | Effect |
@@ -63,6 +73,7 @@ Alternatively, you can change the default values for these arguments directly in
 #### Build an Archive Image for a Different Release of MATLAB
 
 For example, to build an archive image for MATLAB R2023b installation files, use the following command.
+
 ```bash
 docker build --build-arg MATLAB_RELEASE=R2023b -t mpm-archive:R2023b -f archive.Dockerfile .
 ```
@@ -70,11 +81,13 @@ docker build --build-arg MATLAB_RELEASE=R2023b -t mpm-archive:R2023b -f archive.
 #### Build an Archive Image with a specific set of products
 
 For example, to build an image with MATLAB and the Statistics and Machine Learning Toolbox&trade; installation files, use this command.
+
 ```bash
 docker build --build-arg MATLAB_PRODUCT_LIST="MATLAB Statistics_and_Machine_Learning_Toolbox" -t mpm-archive:R2024b -f archive.Dockerfile .
 ```
 
 ### Customize the Product Docker Image
+
 The [Dockerfile](Dockerfile) supports the following Docker build-time variables:
 
 | Argument Name | Default value | Effect |
@@ -88,18 +101,20 @@ The [Dockerfile](Dockerfile) supports the following Docker build-time variables:
 Use these arguments with the `docker build` command to customize your image.
 Alternatively, you can change the default values for these arguments directly in the [Dockerfile](Dockerfile).
 
-
 ### Build an Image for a Different Release of MATLAB
 
 For example, to build an image for MATLAB R2023b, use the following command.
+
 ```bash
 docker build --build-arg MATLAB_RELEASE=R2023b --build-arg ARCHIVE_BASE_IMAGE=mpm-archive:R2023b -t matlab-from-source:R2023b .
 ```
+
 Ensure that the release of the archive base image you set in `ARCHIVE_BASE_IMAGE` matches the one in `MATLAB_RELEASE`.
 
 ### Build an Image with a Specific Set of Products
 
 For example, to build an image with MATLAB and the Statistics and Machine Learning Toolbox, use this command.
+
 ```bash
 docker build --build-arg MATLAB_PRODUCT_LIST="MATLAB Statistics_and_Machine_Learning_Toolbox" -t matlab-stats-from-source:R2024b .
 ```
@@ -107,6 +122,7 @@ docker build --build-arg MATLAB_PRODUCT_LIST="MATLAB Statistics_and_Machine_Lear
 ### Build an Image with MATLAB Installed to a Specific Location
 
 For example, to build an image with MATLAB installed at `/opt/matlab`, use this command.
+
 ```bash
 docker build --build-arg MATLAB_INSTALL_LOCATION="/opt/matlab" -t matlab-from-source:R2024b .
 ```
@@ -114,6 +130,7 @@ docker build --build-arg MATLAB_INSTALL_LOCATION="/opt/matlab" -t matlab-from-so
 ### Build an Image from a Different Archive
 
 For example, to build an image using a different archive image, use the following command.
+
 ```bash
 docker build  --build-arg ARCHIVE_BASE_IMAGE=my-archive -t matlab-from-source:R2024b .
 ```
@@ -121,6 +138,7 @@ docker build  --build-arg ARCHIVE_BASE_IMAGE=my-archive -t matlab-from-source:R2
 #### Build an Image Configured to Use a License Server
 
 Including the license server information with the `docker build` command means you do not have to pass it when running the container.
+
 ```bash
 # Build container with the License Server.
 docker build --build-arg LICENSE_SERVER=27000@MyServerName -t matlab-from-source:R2024b .
@@ -132,10 +150,13 @@ docker run --init --rm matlab-from-source:R2024b -batch ver
 For more information, see [Use the Network License Manager](../../README.md#use-the-network-license-manager).
 
 ## More MATLAB Docker Resources
+
 For more MATLAB Docker resources, see [More MATLAB Docker Resources](../../README.md#more-matlab-docker-resources).
 
 ## Help Make MATLAB Even Better
+
 You can help improve MATLAB by providing user experience information on how you use MathWorks products. Your participation ensures that you are represented and helps us design better products. To opt out of this service, delete the following line in the Dockerfile:
+
 ```Dockerfile
 ENV MW_DDUX_FORCE_ENABLE=true MW_CONTEXT_TAGS=MATLAB:FROM_SOURCE:DOCKERFILE:V1
 ```
@@ -143,6 +164,7 @@ ENV MW_DDUX_FORCE_ENABLE=true MW_CONTEXT_TAGS=MATLAB:FROM_SOURCE:DOCKERFILE:V1
 To learn more, see the documentation: [Help Make MATLAB Even Better - Frequently Asked Questions](https://www.mathworks.com/support/faq/user_experience_information_faq.html).
 
 ## Feedback
+
 We encourage you to try this repository with your environment and provide feedback. If you encounter a technical issue or have an enhancement request, create an issue [here](https://github.com/mathworks-ref-arch/matlab-dockerfile/issues).
 
 ---

--- a/alternates/matlab-installer/README.md
+++ b/alternates/matlab-installer/README.md
@@ -1,8 +1,9 @@
 # Create MATLAB Container Image Using MATLAB Installer
 
-This repository demonstrates how to create a Docker&reg; container image for MATLAB&reg; from local files using the MATLAB installer on a Linux&reg; Operating System. To create a container image for other operating systems, use the appropriate commands. This method provided here uses the MATLAB installer rather than [MATLAB Package Manager (`mpm`)](../../MPM.md). The MATLAB installer is the default graphical installer for MATLAB. 
+This repository demonstrates how to create a Docker&reg; container image for MATLAB&reg; from local files using the MATLAB installer on a Linux&reg; Operating System. To create a container image for other operating systems, use the appropriate commands. This method provided here uses the MATLAB installer rather than [MATLAB Package Manager (`mpm`)](../../MPM.md). The MATLAB installer is the default graphical installer for MATLAB.
 
 The Dockerfile in this subfolder shows you how to use the MATLAB installer with the `-mode silent` flag to install MATLAB without a graphical user interface. Use this Dockerfile if either of these conditions apply.
+
 - You need toolboxes that `mpm` cannot install.
 - You prefer using the MATLAB installer workflow, for example, if you have already set it up in your CI/CD pipeline.
 
@@ -11,22 +12,30 @@ If not, use the [simpler workflow](../../README.md) to build a container image u
 Use the container image as a scalable and reproducible method to deploy MATLAB in a variety of situations, including clouds and clusters.
 
 ## Requirements
-* Docker
-* Git&trade;
+
+- Docker
+
+- Git&trade;
 
 ## Step 1. Clone This Repository
+
 1. Clone this repository using this command.
+
 ```bash
 git clone https://github.com/mathworks-ref-arch/matlab-dockerfile.git
 ```
+
 2. Inside the cloned repository, navigate to the `alternates/matlab-installer` folder.
 3. Create a subfolder named `matlab-install`.
 
 ## Step 2. Choose MATLAB Installation Method
+
 To install MATLAB into the container image, choose a MATLAB installation method. You can either use MATLAB installation files or a MATLAB ISO image.
 
 ### MATLAB Installation Files
+
 To obtain the installation files, you must be an administrator for the license linked with your MathWorks&reg; account.
+
 1. From the [MathWorks Downloads](https://www.mathworks.com/downloads/) page, select the desired version of MATLAB.
 1. Download the Installer for Linux.
 1. Follow the steps at [Download Products Without Installation](https://www.mathworks.com/help/install/ug/download-without-installing.html).
@@ -35,21 +44,25 @@ To obtain the installation files, you must be an administrator for the license l
 1. Select the products you want to install in the container image.
 1. Confirm your selections and complete the download.
 1. **(For MATLAB releases after R2020a)** The installation files are extracted automatically into a subfolder with a date stamp. Move these files up a level using this command from the `matlab-installer` folder.
+
 ```bash
 mv ./matlab-install/<Time Stamp>/* ./matlab-install/
 ```
 
 ### MATLAB ISO
+
 1. From the [MathWorks Downloads](https://www.mathworks.com/downloads/) page, select the desired version of MATLAB.
 1. Next to the text "I WANT TO:" click on the dropdown and select "Get ISOs and DMGs".
 1. Download the Linux ISO image for your desired release of MATLAB.
 1. Extract the ISO into the `matlab-install` subfolder of the cloned repository.
 1. The permissions are not setup correctly on files extracted from an ISO downloaded from MathWorks. To remedy this, run the following command from the `alternates/matlab-installer` folder in the repository.
+
 ```bash
 chmod -R +x ./matlab-install/
 ```
 
 ## Step 3. Obtain the License File and File Installation Key
+
 1. Log in to your [MathWorks Account](https://www.mathworks.com/login). Select the license you want to use with the container.
 1. Select the **Install and Activate** tab.
 1. Click “Activate to Retrieve License File” link.
@@ -59,10 +72,13 @@ chmod -R +x ./matlab-install/
 1. Copy the file installation key into a safe location.
 
 ## Step 4. Define Installation Parameters
+
 1. Copy the file `installer_input.txt` from the `alternates/matlab-installer/matlab-install` folder into the `alternates/matlab-installer` folder and rename the file to `matlab_installer_input.txt`. Use this command to copy the folder and rename the file.
+
 ```bash
 cp ./matlab-install/installer_input.txt ./matlab_installer_input.txt
 ```
+
 2. Open `matlab_installer_input.txt` in a text editor and edit these sections.
     - `fileInstallationKey` - Paste your File Installation Key and uncomment the line.
     - `agreeToLicense` - Set the value to yes and uncomment the line.
@@ -87,18 +103,20 @@ docker build -t matlab:$RELEASE --build-arg MATLAB_RELEASE=$RELEASE --build-arg 
 
 Alternatively, you can change the default values for these arguments directly in the [Dockerfile](https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/Dockerfile).
 
+> [!NOTE]
+> Use the `LICENSE_SERVER` build argument to generate a valid network license file only if you cannot supply a license file. Omit this argument you have a network license file or no network licensing is required. Modify the commands within the Dockerfile as described within it.
 
-**Note**: Use the `LICENSE_SERVER` build argument to generate a valid network license file only if you cannot supply a license file. Omit this argument you have a network license file or no network licensing is required. Modify the commands within the Dockerfile as described within it.
-
-**Note**: The build process uses approximately 4GB of RAM, so ensure that the Docker service has sufficient resources.
-
+> [!NOTE]
+> The build process uses approximately 4GB of RAM, so ensure that the Docker service has sufficient resources.
 
 ## Step 6. Run Container
+
 Run the container using a command with this form.
 
 ```bash
 docker run --init -it --rm matlab:$RELEASE
 ```
+
 - `-it` option runs the container interactively.
 - `--rm` option automatically removes the container on exit.
 
@@ -120,9 +138,10 @@ Insert any extra arguments after the container tag to add as command line argume
 docker run --init -it --rm matlab:$RELEASE -batch "ver"
 ```
 
-
 ## Use a License File to Build Image
+
 If you have a `license.dat` file from your license administrator, use this file to provide the location of the license manager for the container image.
+
 1. Open the `license.dat` file. Copy the `SERVER` line into a new text file.
 2. Beneath it, add `USE_SERVER`. The file should now look similar to this.
 

--- a/alternates/non-interactive/MATLAB-BATCH.md
+++ b/alternates/non-interactive/MATLAB-BATCH.md
@@ -4,39 +4,45 @@ MATLAB&reg; batch licensing executable (**matlab-batch**) is a command line tool
 
 The MATLAB batch licensing project is still in the pilot phase. To inquire about eligibility requirements, fill out this form on the MathWorks&reg; website: [Batch Licensing Pilot Eligibility](https://www.mathworks.com/support/batch-tokens.html).
 
-
 ## Install MATLAB Batch Licensing Executable
 
-You can install the MATLAB batch licensing executable either by using the installer script or by downloading it and setting it up manually. 
+You can install the MATLAB batch licensing executable either by using the installer script or by downloading it and setting it up manually.
 
-The installer script sets up the MATLAB Batch Licensing Executable in a default location and adds it to your system path for easy command line access. It also allows you to install the executable in a preferred location. 
+The installer script sets up the MATLAB Batch Licensing Executable in a default location and adds it to your system path for easy command line access. It also allows you to install the executable in a preferred location.
 
 ### Install MATLAB Batch Licensing Executable Using the Installer Script
 
 On macOS, Linux&reg;, and emulated Linux environments (Cygwin&trade;, MinGW&reg;, MSYS2) on Windows&reg;, use the following commands to install `matlab-batch`:
+
 ```bash
 curl -s 'https://raw.githubusercontent.com/mathworks-ref-arch/matlab-dockerfile/main/alternates/non-interactive/install/install-matlab-batch.sh' -o 'install-matlab-batch.sh'
 sudo bash ./install-matlab-batch.sh 
 ```
 
 To install it in a custom location, such as `/opt/my-custom-installs/`, use this command:
+
 ```bash
 sudo bash ./install-matlab-batch.sh -i '/opt/my-custom-location'
 ```
-> Note: the -i option accepts both absolute and relative paths.
+
+> [!NOTE]
+> the -i option accepts both absolute and relative paths.
 
 On Windows, use the following commands to install `matlab-batch` in a PowerShell session with elevated permissions (you must start PowerShell with the "Run as Administrator" option):
+
 ```powershell
 Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/mathworks-ref-arch/matlab-dockerfile/main/alternates/non-interactive/install/install-matlab-batch.ps1' -OutFile 'install-matlab-batch.ps1'
 .\install-matlab-batch.ps1
 ```
 
-To install it in a custom location, such as `C:\Program Files\my-custom-location`, use this command: 
+To install it in a custom location, such as `C:\Program Files\my-custom-location`, use this command:
+
 ```powershell
 .\install-matlab-batch.ps1 -InstallLocation 'C:\Program Files\my-custom-location'
 ```
 
-> Note: the -InstallLocation option accepts both absolute and relative paths.
+> [!NOTE]
+> the -InstallLocation option accepts both absolute and relative paths.
 
 ### Download MATLAB Batch Licensing Executable and Install Manually
 
@@ -78,20 +84,22 @@ Give the downloaded file executable permissions so that you can run `matlab-batc
 
 ## Syntax
 
-- `matlab-batch -licenseToken <token> <statement>` starts MATLAB using the batch licensing token `<token>` and then runs the MATLAB statement `<statement>`. You can omit the `-licenseToken` argument if you specify the batch licensing token in the `MLM_LICENSE_TOKEN` environment variable. [Example](#hello-world)
+* `matlab-batch -licenseToken <token> <statement>` starts MATLAB using the batch licensing token `<token>` and then runs the MATLAB statement `<statement>`. You can omit the `-licenseToken` argument if you specify the batch licensing token in the `MLM_LICENSE_TOKEN` environment variable. [Example](#hello-world)
 
-- `matlab-batch -licenseToken <token> <option1> ... <optionN> <statement>` specifies MATLAB start-up options using one or more option flags `<optionX>`. [Example](#run-matlab-with-startup-options)
+* `matlab-batch -licenseToken <token> <option1> ... <optionN> <statement>` specifies MATLAB start-up options using one or more option flags `<optionX>`. [Example](#run-matlab-with-startup-options)
 
-- `matlab-batch <globalOption>` specifies a global option `<globalOption>`, ignoring other input arguments. For example, you can show the help or the installed version of **matlab-batch**.
+* `matlab-batch <globalOption>` specifies a global option `<globalOption>`, ignoring other input arguments. For example, you can show the help or the installed version of **matlab-batch**.
 
-> **Note: Selecting the MATLAB executable to start**
+> [!NOTE]
+> **Selecting the MATLAB executable to start**
 >
->  If the **matlab-batch** executable is in a folder containing a **matlab** (case-sensitive) executable, it starts that MATLAB.
+> If the **matlab-batch** executable is in a folder containing a **matlab** (case-sensitive) executable, it starts that MATLAB.
 > Otherwise, it starts the first MATLAB on your PATH environment variable.
 
 ## Examples
 
-### Hello, World.
+### Hello, World
+
 To execute a MATLAB statement, navigate to the folder containing the `matlab-batch` binary file and run the following command.
 
     ./matlab-batch -licenseToken "user@email.com|encodedToken" "disp('Hello, World.')"
@@ -102,6 +110,7 @@ You can also provide your MATLAB batch licensing token with the `MLM_LICENSE_TOK
     ./matlab-batch "disp('Hello, World.')"
 
 ### Run MATLAB with Startup Options
+
 To run MATLAB with any set of arguments, such as `-logfile`, execute:
 
     ./matlab-batch -licenseToken "user@email.com|encodedToken" -logfile "logfilename.log" "myscript"
@@ -109,6 +118,7 @@ To run MATLAB with any set of arguments, such as `-logfile`, execute:
 To learn more, see the documentation: [Commonly Used Startup Options](https://www.mathworks.com/help/matlab/matlab_env/commonly-used-startup-options.html).
 
 ## Global Options
+
 | Option                        | Description                                         | Example                                    |
 | ----------------------------- | --------------------------------------------------- | ------------------------------------------ |
 | `-help` or `-h`               | Flag for showing help.                              | `matlab-batch -help`                       |
@@ -117,6 +127,7 @@ To learn more, see the documentation: [Commonly Used Startup Options](https://ww
 | `-display3pLicenseAgreements` | Flag for showing the third-party software licenses. | `matlab-batch -display3pLicenseAgreements` |
 
 ## Batch Options
+
 | Option          | Description | Example |
 | --------------- | ----------- | ------- |
 | `-licenseToken` | MATLAB batch licensing token. Related environment variable: `MLM_LICENSE_TOKEN`. | `user@email.com\|label\|encodedToken`, `user@email.com\|encodedToken` |
@@ -126,8 +137,9 @@ To learn more, see the documentation: [Commonly Used Startup Options](https://ww
 MATLAB batch licensing tokens are strings that enable MATLAB to start in non-interactive environments. A token is a unique identifier that grants access to your MATLAB products.
 
 MATLAB batch licensing tokens come in two formats:
- - `user@email.com|encodedToken`
- - `user@email.com|label|encodedToken`
+
+* `user@email.com|encodedToken`
+* `user@email.com|label|encodedToken`
 
 These tokens can be used instead of, or in addition to, other types of licensing.
 
@@ -135,11 +147,12 @@ If your batch licensing token expires in less than 30 days, **matlab-batch** pri
 
 ## Limitations
 
- - R2020b is the oldest release that **matlab-batch** supports on Linux and macOS with Intel&reg;.
- - R2021a is the oldest release that **matlab-batch** supports on Windows.
- - R2023b is the oldest release that **matlab-batch** supports on macOS with Apple silicon.
+* R2020b is the oldest release that **matlab-batch** supports on Linux and macOS with Intel&reg;.
+* R2021a is the oldest release that **matlab-batch** supports on Windows.
+* R2023b is the oldest release that **matlab-batch** supports on macOS with Apple silicon.
 
 ## Feedback and Support
+
 To inquire about eligibility requirements for the MATLAB batch licensing pilot, fill out this form on the MathWorks website: [Batch Licensing Pilot Eligibility](https://www.mathworks.com/support/batch-tokens.html).
 
 For support, contact [MathWorks Technical Support](https://www.mathworks.com/support/contact_us.html).
@@ -147,50 +160,57 @@ For support, contact [MathWorks Technical Support](https://www.mathworks.com/sup
 ## Changelog
 
 ### v2025.01.0
-- **Added:** Support for MATLAB R2025a prerelease.
+
+* **Added:** Support for MATLAB R2025a prerelease.
 
 ### v2024.10.0
-- **Fixed:** Robustness of error reporting.
+
+* **Fixed:** Robustness of error reporting.
 
 ### v2024.09.0
-- **Fixed:** Error reporting related to MATLAB shutdown.
- 
+
+* **Fixed:** Error reporting related to MATLAB shutdown.
+
 ### v2024.07.0
-- **Added:** Internal changes to support upcoming features.
+
+* **Added:** Internal changes to support upcoming features.
 
 ### v2024.06.1
-- **Added:** Support for MATLAB R2024b.
+
+* **Added:** Support for MATLAB R2024b.
 
 ### v2024.06.0
-- **Fixed:** Error message on finding an unsupported old MATLAB release.
-- **Added:** Warning messages when **matlab-batch** will soon expire.
+
+* **Fixed:** Error message on finding an unsupported old MATLAB release.
+
+* **Added:** Warning messages when **matlab-batch** will soon expire.
 
 ### v2024.05.0
 
-- **Added:** Notification when **matlab-batch** requires redownloading.
-- **Added:** Trimming of whitespace from front and back of tokens.
-- **Fixed:** Robustness against poor network conditions.
+* **Added:** Notification when **matlab-batch** requires redownloading.
+* **Added:** Trimming of whitespace from front and back of tokens.
+* **Fixed:** Robustness against poor network conditions.
 
 ### v2024.02.1
 
-- **Added:** Support for macOS with Apple silicon.
+* **Added:** Support for macOS with Apple silicon.
 
 ### v2024.02.0
 
-- **Added:** Support for MATLAB R2024a.
-- **Added:** Notifications when tokens are close to expiring.
-- **Added:** File details (including application version) integrated with Windows Explorer.
-- **Fixed:** **matlab-batch** supports Parallel Computing workflows.
-- **Fixed:** Improved ability to detect valid MATLAB installations.
+* **Added:** Support for MATLAB R2024a.
+* **Added:** Notifications when tokens are close to expiring.
+* **Added:** File details (including application version) integrated with Windows Explorer.
+* **Fixed:** **matlab-batch** supports Parallel Computing workflows.
+* **Fixed:** Improved ability to detect valid MATLAB installations.
 
 ### v2023.10.1
 
-- **Added:** Support for MATLAB R2023b.
+* **Added:** Support for MATLAB R2023b.
 
 ### v2023.10.0
 
-- **Added:** Initial release.
-- **Added:** Support for MATLAB R2020b to R2023a.
+* **Added:** Initial release.
+* **Added:** Support for MATLAB R2020b to R2023a.
 
 ---
 Copyright 2024 The MathWorks, Inc.


### PR DESCRIPTION
Modify the syntax of the warning alert module in the markdown files to make it more noticeable for readers, referencing the official GitHub documentation.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
