### PR TITLE
Add proxy environmental variables to mpm call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /home/matlab
 # Pass in $HOME variable to install support packages into the user's HOME folder.
 RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm \
     && chmod +x mpm \
-    && sudo HOME=${HOME} ./mpm install \
+    && sudo HOME=${HOME} HTTP_PROXY=${HTTP_PROXY} HTTPS_PROXY=${HTTP_PROXY} ./mpm install \
     --release=${MATLAB_RELEASE} \
     --destination=${MATLAB_INSTALL_LOCATION} \
     --products ${MATLAB_PRODUCT_LIST} \


### PR DESCRIPTION
Currently mpm does not use any proxy environmental variables even if they are set. This patch supports setting proxy vars via `build-args`, e.g. `docker build --build-arg HTTPS_PROXY=http://<my-proxy>:<port> --build-arg HTTP_PROXY=http://<my-proxy>:<port> .`