### PR TITLE
Upgrade CI dependencies

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           load: true

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup runner
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -74,7 +74,7 @@ jobs:
             ${{ env.IMAGE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/from-matlab-docker-build-test.yml
+++ b/.github/workflows/from-matlab-docker-build-test.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/from-matlab-docker-build-test.yml
+++ b/.github/workflows/from-matlab-docker-build-test.yml
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/from-matlab-docker-build-test.yml
+++ b/.github/workflows/from-matlab-docker-build-test.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup runner
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/from-matlab-docker-build-test.yml
+++ b/.github/workflows/from-matlab-docker-build-test.yml
@@ -65,7 +65,7 @@ jobs:
             ${{ env.IMAGE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/matlab-container-offline-install-build-test.yml
+++ b/.github/workflows/matlab-container-offline-install-build-test.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup runner
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/matlab-container-offline-install-build-test.yml
+++ b/.github/workflows/matlab-container-offline-install-build-test.yml
@@ -62,7 +62,7 @@ jobs:
           driver: docker
 
       - name: Build archive image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}
@@ -75,7 +75,7 @@ jobs:
             ${{ env.ARCHIVE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Build final image offline
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/matlab-container-offline-install-build-test.yml
+++ b/.github/workflows/matlab-container-offline-install-build-test.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ env.IMAGE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/matlab-container-offline-install-build-test.yml
+++ b/.github/workflows/matlab-container-offline-install-build-test.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 

--- a/.github/workflows/matlab-installer-build-test.yml
+++ b/.github/workflows/matlab-installer-build-test.yml
@@ -61,7 +61,7 @@ jobs:
           cp tests/${{ env.ALT_PATH }}/mocks/matlab_installer_input.txt ./${{ env.ALT_PATH }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/matlab-installer-build-test.yml
+++ b/.github/workflows/matlab-installer-build-test.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/matlab-installer-build-test.yml
+++ b/.github/workflows/matlab-installer-build-test.yml
@@ -75,7 +75,7 @@ jobs:
         run: python -m unittest ${{ env.ALT_PATH }}/test_failing_build.py
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/matlab-installer-build-test.yml
+++ b/.github/workflows/matlab-installer-build-test.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup runner
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build image locally
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup runner
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -75,7 +75,7 @@ jobs:
             ${{ env.IMAGE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/windows-container-build-test-publish.yml
+++ b/.github/workflows/windows-container-build-test-publish.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build the Docker image
         run: |

--- a/.github/workflows/windows-container-build-test-publish.yml
+++ b/.github/workflows/windows-container-build-test-publish.yml
@@ -61,7 +61,7 @@ jobs:
           ./Makefile.ps1 Test -ImageName ${{ env.IMAGE_BASE_NAME }} -Release ${{ matrix.matlab-release }} -Token ${{ secrets.MATLAB_BATCH_TOKEN_EXPIRES_03_2026 }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Update actions across the board, especially in the light of [Node.js 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

See warnings in e.g. https://github.com/mathworks-ref-arch/matlab-dockerfile/actions/runs/22948668917:
```console
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, docker/build-push-action@v5, docker/setup-buildx-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```