### PR TITLE
Pin docker/* actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -55,17 +55,17 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Build image locally
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           load: true

--- a/.github/workflows/from-matlab-docker-build-test.yml
+++ b/.github/workflows/from-matlab-docker-build-test.yml
@@ -52,10 +52,10 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Build image locally
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/matlab-container-offline-install-build-test.yml
+++ b/.github/workflows/matlab-container-offline-install-build-test.yml
@@ -58,12 +58,12 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
         with:
           driver: docker
 
       - name: Build archive image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}
@@ -76,7 +76,7 @@ jobs:
             ${{ env.ARCHIVE_BASE_NAME }}:${{ matrix.matlab-release }}
 
       - name: Build final image offline
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/matlab-installer-build-test.yml
+++ b/.github/workflows/matlab-installer-build-test.yml
@@ -76,10 +76,10 @@ jobs:
         run: python -m unittest ${{ env.ALT_PATH }}/test_failing_build.py
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Build image locally
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/non-interactive-build-test.yml
+++ b/.github/workflows/non-interactive-build-test.yml
@@ -55,17 +55,17 @@ jobs:
         uses: ./.github/actions/cleanup-runner
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Build image locally
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           platforms: linux/amd64
           context: ${{ env.ALT_PATH }}

--- a/.github/workflows/windows-container-build-test-publish.yml
+++ b/.github/workflows/windows-container-build-test-publish.yml
@@ -62,7 +62,7 @@ jobs:
           ./Makefile.ps1 Test -ImageName ${{ env.IMAGE_BASE_NAME }} -Release ${{ matrix.matlab-release }} -Token ${{ secrets.MATLAB_BATCH_TOKEN_EXPIRES_03_2026 }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Addresses plumber ISSUE-701 by pinning all docker/login-action, docker/setup-buildx-action, and docker/build-push-action references to full commit SHAs (with version comments). Adds a Dependabot config to keep them updated weekly, grouped into a single PR.